### PR TITLE
OpenMP improvements

### DIFF
--- a/ap_features/ap_features.py
+++ b/ap_features/ap_features.py
@@ -143,6 +143,10 @@ def all_cost_terms_c(
     mask: Optional[np.ndarray] = None,
     normalize_time: bool = True,
 ) -> np.ndarray:
+    # check that the number of trace points is consistent
+    assert t.shape[0] == arr.shape[0]
+    num_trace_points = t.shape[0]
+
     traces = transpose_trace_array(arr[...])
     num_sets = traces.shape[0]
     if mask is None:
@@ -164,8 +168,10 @@ def all_cost_terms_c(
         t = t - t[0]
     R = np.zeros((num_sets, NUM_COST_TERMS))
     lib.all_cost_terms(
-        R, traces, t[...], mask[...], t.size, num_sets, update_progress_func
+        R, traces, t[...], mask[...], num_trace_points, num_sets, update_progress_func
     )
+    if progress_bar:
+        progress_bar.close()
     return R
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,12 @@ def check_for_openmp():
     CCODE = """
     #include <omp.h>
     #include <stdio.h>
+
     int main(void) {
-    #pragma omp parallel
-    printf("nthreads=%d\\n", omp_get_num_threads());
-    return 0;
+        #pragma omp parallel
+        printf("nthreads=%d\\n", omp_get_num_threads());
+
+        return 0;
     }
     """
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_openmp_compile_args():
 
 
 def get_openmp_link_args():
-    extra_link_args = ["-lgomp"]
+    extra_link_args = ["-fopenmp"]
     if sys.platform == "darwin":
         extra_link_args = ["-lomp"]
     return extra_link_args

--- a/src/cost_terms.c
+++ b/src/cost_terms.c
@@ -316,7 +316,7 @@ double trapz(double *V, double *T, int length, double extra)
     double h;
 
     // Compute the integral of sin(X) using Trapezoidal numerical integration method
-    for (int j; j < length - 1; ++j) {
+    for (int j = 0; j < length - 1; ++j) {
         h = T[j + 1] - T[j];
         // if (j == 0 || j == length - 1) // for the first and last elements
         //     sum += h * (V[j] + extra) / 2;

--- a/src/cost_terms.c
+++ b/src/cost_terms.c
@@ -399,7 +399,7 @@ void all_cost_terms(double *R, double *traces, double *t, uint8_t *mask, long le
 #if defined(_OPENMP)
     int num_threads = omp_get_max_threads();
 #else
-    int num_threads = 0;
+    int num_threads = 1;
 #endif
     int stride = 8; // we choose stride to be CACHE_LINE_SIZE / sizeof(long) = 8
     long parameter_sets_computed_per_thread[num_threads * stride];


### PR DESCRIPTION
This PR fixes a few minor issues, some of which are related to OpenMP. 
- The progress update should now work also when OpenMP is unavailable.
- A loop variable in the `trapz` function wasn't initialised properly.
- I switched the linking flag on Linux to `-fopenmp`, since that is the recommended method with GCC and Clang.