### PR TITLE
Support dask and h5py and implement a few more classes 

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 black
 bump2version
+dask[array]
 flake8
+h5py
 ipython
 isort
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,9 @@ where = src/python
 [options.extras_require]
 all =
     black
+    dask[array]
     flake8
+    h5py
     ipython
     isort
     mypy

--- a/src/python/ap_features/__init__.py
+++ b/src/python/ap_features/__init__.py
@@ -6,7 +6,7 @@ __version__ = "0.1.0"
 from . import background, chopping, features
 from ._c import NUM_COST_TERMS
 from ._numba import transpose_trace_array
-from .beat import Beat, BeatSeries, Trace
+from .beat import Beat, BeatSeries, Trace, BeatCollection, StateCollection, State
 from .features import all_cost_terms, apd, apd_up_xy, cost_terms, cost_terms_trace
 from .utils import Backend, list_cost_function_terms, list_cost_function_terms_trace
 
@@ -28,4 +28,7 @@ __all__ = [
     "BeatSeries",
     "background",
     "chopping",
+    "BeatCollection",
+    "StateCollection",
+    "State",
 ]

--- a/src/python/ap_features/_c.py
+++ b/src/python/ap_features/_c.py
@@ -12,6 +12,7 @@ from scipy import interpolate
 from .lib import lib
 from .utils import _check_factor
 from .utils import Array
+from .utils import numpyfy
 
 logger = logging.getLogger(__name__)
 NUM_COST_TERMS = lib.get_num_cost_terms()
@@ -63,6 +64,8 @@ def apd(y: Array, t: Array, factor: interpolate) -> float:
 
     """
     _check_factor(factor)
+    y = to_c_contigous(y)
+    t = to_c_contigous(t)
     return lib.apd(
         np.array(y)[...],
         np.array(t)[...],
@@ -73,6 +76,9 @@ def apd(y: Array, t: Array, factor: interpolate) -> float:
 
 
 def apd_up_xy(y: np.ndarray, t: np.ndarray, factor_x: int, factor_y: int) -> float:
+    y = to_c_contigous(y)
+    t = to_c_contigous(t)
+
     return lib.apd_up_xy(
         np.array(y)[...],
         np.array(t)[...],
@@ -84,10 +90,19 @@ def apd_up_xy(y: np.ndarray, t: np.ndarray, factor_x: int, factor_y: int) -> flo
 
 
 def cost_terms_trace(y: np.ndarray, t: np.ndarray) -> np.ndarray:
-
     R = np.zeros(NUM_COST_TERMS // 2)
+    y = to_c_contigous(y)
+    t = to_c_contigous(t)
     lib.cost_terms_trace(R, y[...], t[...], t.size)
     return R
+
+
+def to_c_contigous(y: np.ndarray) -> np.ndarray:
+
+    y = numpyfy(y)
+    if not y.flags.c_contiguous:
+        y = np.ascontiguousarray(y)
+    return y
 
 
 def cost_terms(
@@ -97,6 +112,12 @@ def cost_terms(
     t_ca: np.ndarray,
 ) -> np.ndarray:
     R = np.zeros(NUM_COST_TERMS)
+
+    v = to_c_contigous(v)
+    ca = to_c_contigous(ca)
+    t_v = to_c_contigous(t_v)
+    t_ca = to_c_contigous(t_ca)
+
     lib.cost_terms_trace(R[: NUM_COST_TERMS // 2], v[...], t_v[...], t_v.size)
     lib.cost_terms_trace(R[NUM_COST_TERMS // 2 :], ca[...], t_ca[...], t_ca.size)
     return R

--- a/src/python/ap_features/_c.py
+++ b/src/python/ap_features/_c.py
@@ -11,7 +11,6 @@ from scipy import interpolate
 
 from .lib import lib
 from .utils import _check_factor
-from .utils import Array
 from .utils import numpyfy
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ def py_update_progress(progress_bar: Optional[tqdm.tqdm] = None) -> Callable:
     return py_update_progress_wrap
 
 
-def apd(y: Array, t: Array, factor: interpolate) -> float:
+def apd(y: np.ndarray, t: np.ndarray, factor: interpolate) -> float:
     """Return the action potential duration at the given factor.
 
     Parameters

--- a/src/python/ap_features/beat.py
+++ b/src/python/ap_features/beat.py
@@ -4,16 +4,13 @@ from typing import Optional
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 
-<<<<<<< HEAD
 from . import background
 from . import chopping
 from . import features
 from .utils import Array
+from .utils import Backend
 from .utils import normalize_signal
-=======
-from . import background, chopping, features
-from .utils import Array, Backend, normalize_signal
->>>>>>> Start adding classes for Beatcollection
+from .utils import numpyfy
 
 
 class Trace:
@@ -27,17 +24,12 @@ class Trace:
 
         if t is None:
             t = np.arange(len(y))
-        self._t = np.array(t)
-        self._y = np.array(y)
+        self._t = numpyfy(t)
+        self._y = numpyfy(y)
         if pacing is None:
-            pacing = np.zeros_like(self._y)  # type: ignore
+            pacing = np.zeros_like(self._t)  # type: ignore
 
-        msg = (
-            "Expected shape of 't' and 'y' to be the same got "
-            f"{self._t.shape}(t) and {self._y.shape}(y)"
-        )
-        assert self._t.shape == self._y.shape, msg
-        self._pacing = np.array(pacing)
+        self._pacing = numpyfy(pacing)
 
         assert backend in Backend
         self._backend = backend
@@ -66,9 +58,15 @@ class Beat(Trace):
         pacing: Optional[Array] = None,
         y_rest: Optional[float] = None,
         parent: Optional["BeatSeries"] = None,
+        backend: Backend = Backend.c,
     ) -> None:
 
-        super().__init__(y, t, pacing)
+        super().__init__(y, t, pacing=pacing, backend=backend)
+        msg = (
+            "Expected shape of 't' and 'y' to be the same. got "
+            f"{self._t.shape}(t) and {self._y.shape}(y)"
+        )
+        assert self._t.shape == self._y.shape, msg
         self._y_rest = y_rest
         self._parent = parent
 
@@ -172,6 +170,7 @@ class Beat(Trace):
     def apd_up(self, factor_x, factor_y):
         pass
 
+    @property
     def cost_terms(self):
         return features.cost_terms_trace(y=self.y, t=self.t, backend=self._backend)
 
@@ -183,12 +182,18 @@ class BeatSeries(Trace):
         t: Array,
         pacing: Optional[Array] = None,
         correct_background: bool = False,
+        backend: Backend = Backend.c,
     ) -> None:
         self._background = None
         if correct_background:
             self._background = background.correct_background(x=t, y=y)
 
-        super().__init__(y, t, pacing=pacing)
+        super().__init__(y, t, pacing=pacing, backend=backend)
+        msg = (
+            "Expected shape of 't' and 'y' to be the same got "
+            f"{self._t.shape}(t) and {self._y.shape}(y)"
+        )
+        assert self._t.shape == self._y.shape, msg
 
     def chop(self, **options) -> List[Beat]:
         c = chopping.chop_data(data=self.y, time=self.t, pacing=self.pacing, **options)
@@ -222,11 +227,25 @@ class BeatCollection(Trace):
         y: Array,
         t: Array,
         pacing: Optional[Array] = None,
+        mask: Optional[Array] = None,
         parent: Optional["BeatSeriesCollection"] = None,
+        backend: Backend = Backend.c,
     ) -> None:
-        # TODO: Check dimensions
-        super().__init__(y=y, t=t, pacing=pacing)
+
+        super().__init__(y, t, pacing=pacing, backend=backend)
         self._parent = parent
+        msg = (
+            "Expected first dimension of 'y' to be the same as shape of 't' "
+            f", got {self._t.size}(t) and {self._y.shape[0]}(y)"
+        )
+        assert self.t.size == self.y.shape[0], msg
+        assert (
+            len(self.y.shape) == 2
+        ), f"Expected shape of y to be 2D, got {len(self.y.shape)}D"
+
+    @property
+    def num_traces(self):
+        return self.y.shape[-1]
 
     @property
     def parent(self) -> Optional["BeatSeriesCollection"]:
@@ -242,6 +261,107 @@ class BeatCollection(Trace):
 
 
 class BeatSeriesCollection(Trace):
+    pass
+
+    @property
+    def num_beats(self) -> List[int]:
+        raise NotImplementedError
+
+
+class State(Trace):
+    def __init__(
+        self,
+        y: Array,
+        t: Optional[Array],
+        pacing: Optional[Array] = None,
+        backend: Backend = Backend.c,
+    ) -> None:
+        super().__init__(y, t, pacing=pacing, backend=backend)
+
+        msg = (
+            "Expected first dimension of 'y' to be the same as shape of 't' "
+            f", got {self._t.size}(t) and {self._y.shape[0]}(y)"
+        )
+        assert self.t.size == self.y.shape[0], msg
+        assert (
+            len(self.y.shape) == 2
+        ), f"Expected shape of y to be D, got {len(self.y.shape)}D"
+
+    @property
+    def num_states(self):
+        return self.y.shape[1]
+
+    def __getitem__(self, k):
+        return self.y[:, k]
+
+    @property
+    def cost_terms(self):
+        if self.num_states != 2:
+            raise NotImplementedError
+
+        return features.cost_terms(v=self[0], ca=self[1], t_v=self.t, t_ca=self.t)
+
+
+class StateCollection(Trace):
+    def __init__(
+        self,
+        y: Array,
+        t: Array,
+        pacing: Optional[Array] = None,
+        mask: Optional[Array] = None,
+        parent: Optional["StateSeriesCollection"] = None,
+    ) -> None:
+        # TODO: Check dimensions
+        super().__init__(y=y, t=t, pacing=pacing)
+        self._parent = parent
+
+        msg = (
+            "Expected first dimension of 'y' to be the same as shape of 't' "
+            f", got {self._t.size}(t) and {self._y.shape[0]}(y)"
+        )
+        assert self.t.size == self.y.shape[0], msg
+        assert (
+            len(self.y.shape) == 3
+        ), f"Expected shape of y to be 3D, got {len(self.y.shape)}D"
+        self.mask = mask
+
+    @property
+    def mask(self) -> Optional[Array]:
+        return self._mask
+
+    @mask.setter
+    def mask(self, mask: Optional[Array]) -> None:
+        if mask is not None:
+            mask = numpyfy(mask)
+            assert mask.size == self.num_traces
+        self._mask = mask
+
+    @property
+    def num_traces(self):
+        return self.y.shape[-1]
+
+    @property
+    def num_states(self):
+        return self.y.shape[1]
+
+    @property
+    def parent(self) -> Optional["StateSeriesCollection"]:
+        """If the beat comes from a BeatSeries
+        object then this will return that BeatSeries
+
+        Returns
+        -------
+        BeatSeries
+            The parent BeatSeries
+        """
+        return self._parent
+
+    @property
+    def cost_terms(self):
+        return features.all_cost_terms(arr=self.y, t=self.t, mask=self.mask)
+
+
+class StateSeriesCollection(Trace):
     pass
 
     @property

--- a/src/python/ap_features/features.py
+++ b/src/python/ap_features/features.py
@@ -13,6 +13,7 @@ from . import utils
 from .utils import _check_factor
 from .utils import Array
 from .utils import Backend
+from .utils import numpyfy
 
 logger = logging.getLogger(__name__)
 
@@ -784,12 +785,6 @@ def corrected_apd(apd, beat_rate, formula="friderica"):
         return np.multiply(apd, pow(RR, -1 / 2))
 
 
-def numpyfy(y: Array) -> np.ndarray:
-    if not isinstance(y, np.ndarray):
-        y = np.array(y)
-    return y
-
-
 def cost_terms_trace(y: Array, t: Array, backend: Backend = Backend.c) -> np.ndarray:
     y = numpyfy(y)
     t = numpyfy(t)
@@ -837,6 +832,9 @@ def all_cost_terms(
     backend: Backend = Backend.c,
     normalize_time: bool = True,
 ) -> np.ndarray:
+
+    arr = numpyfy(arr)
+    t = numpyfy(t)
     if not isinstance(arr, np.ndarray):
         raise TypeError(f"Expected 'arr' to be of type numpy.ndarray got {type(arr)}")
     if not isinstance(t, np.ndarray):

--- a/src/python/ap_features/features.py
+++ b/src/python/ap_features/features.py
@@ -236,15 +236,9 @@ def tau(
     float
         Decay time
 
-    Raises
-    ------
-    NotImplementedError
-        If unsupported backend is used
     """
     if backend != Backend.python:
-        raise NotImplementedError(
-            "Method currently only implemented for python backend",
-        )
+        logger.warning("Method currently only implemented for python backend")
 
     Y = UnivariateSpline(x, utils.normalize_signal(y) - a, s=0, k=3)
     t_max = x[int(np.argmax(y))]
@@ -299,15 +293,9 @@ def time_to_peak(
     float
         Time to peak
 
-    Raises
-    ------
-    NotImplementedError
-        If unsupported backend is used
     """
     if backend != Backend.python:
-        raise NotImplementedError(
-            "Method currently only implemented for python backend",
-        )
+        logger.warning("Method currently only implemented for python backend")
 
     if pacing is None:
         return x[int(np.argmax(y))]
@@ -362,15 +350,11 @@ def upstroke(
 
     Raises
     ------
-    NotImplementedError
-        If unsupported backend is used
     ValueError
         If a is outside the range of (0, 1)
     """
     if backend != Backend.python:
-        raise NotImplementedError(
-            "Method currently only implemented for python backend",
-        )
+        logger.warning("Method currently only implemented for python backend")
 
     if not 0 < a < 1:
         raise ValueError("'a' has to be between 0.0 and 1.0")
@@ -811,7 +795,7 @@ def cost_terms_trace(y: Array, t: Array, backend: Backend = Backend.c) -> np.nda
     t = numpyfy(t)
 
     if backend == Backend.python:
-        raise NotImplementedError(
+        logger.warning(
             "Method currently not implemented for python backend (and will probably not be)",
         )
 
@@ -835,7 +819,7 @@ def cost_terms(
     t_ca = numpyfy(t_ca)
 
     if backend == Backend.python:
-        raise NotImplementedError(
+        logger.warning(
             "Method currently not implemented for python backend (and will probably not be)",
         )
 
@@ -865,7 +849,7 @@ def all_cost_terms(
         t = t - t[0]
 
     if backend == Backend.python:
-        raise NotImplementedError(
+        logger.warning(
             "Method currently not implemented for python backend (and will probably not be)",
         )
     if backend == Backend.numba:

--- a/src/python/ap_features/utils.py
+++ b/src/python/ap_features/utils.py
@@ -27,7 +27,7 @@ def _check_factor(factor: float) -> None:
         )
 
 
-def numpyfy(y: Array) -> np.ndarray:
+def numpyfy(y) -> np.ndarray:
     if isinstance(y, (list, tuple)):
         y = np.array(y)
 

--- a/src/python/ap_features/utils.py
+++ b/src/python/ap_features/utils.py
@@ -27,6 +27,29 @@ def _check_factor(factor: float) -> None:
         )
 
 
+def numpyfy(y: Array) -> np.ndarray:
+    if isinstance(y, (list, tuple)):
+        y = np.array(y)
+
+    try:
+        import dask.array as da
+    except ImportError:
+        pass
+    else:
+        if isinstance(y, da.Array):
+            y = y.compute()
+
+    try:
+        import h5py
+    except ImportError:
+        pass
+    else:
+        if isinstance(y, h5py.Dataset):
+            y = y[...]
+
+    return y
+
+
 def normalize_signal(V, v_r=None):
     """
     Normalize signal to have maximum value 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,33 @@ def single_beat(multiple_beats):
 
 
 @pytest.fixture(scope="session")
+def NUM_TRACES():
+    return 5
+
+
+@pytest.fixture(scope="session")
+def NUM_STATES():
+    return 2
+
+
+@pytest.fixture(scope="session")
+def single_beat_collection(single_beat, NUM_TRACES):
+    t, y = single_beat
+    # Create N duplicates
+    ys = np.repeat(y, NUM_TRACES).reshape(-1, NUM_TRACES)
+    return t, ys
+
+
+@pytest.fixture(scope="session")
+def state_collection_data(single_beat, NUM_TRACES, NUM_STATES):
+    t, y = single_beat
+    ys = np.repeat(y, NUM_STATES * NUM_TRACES).reshape(-1, NUM_STATES, NUM_TRACES)
+    return t, ys
+
+
+@pytest.fixture(scope="session")
 def triangle_signal():
     x = np.arange(301, dtype=float)
-
     y = np.zeros(301, dtype=float)
     y[:101] = np.linspace(0, 1, 101)
     y[101:201] = np.linspace(1, 0, 101)[1:]

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1,44 +1,110 @@
+import ap_features as apf
+import dask.array as da
+import h5py
+import numpy as np
 import pytest
-from ap_features import Beat
-from ap_features import BeatSeries
-from ap_features import Trace
 
 
-@pytest.fixture(scope="session")
-def trace(single_beat):
+def handle_request_param(request, t, y, cls):
+    if request.param == "numpy":
+        yield cls(y, t)
+    elif request.param == "dask":
+        y_ = da.from_array(y)
+        t_ = da.from_array(t)
+        yield cls(y_, t_)
+    else:
+        # Create an in memory file
+        fp = h5py.File(name=cls.__name__, mode="w", driver="core", backing_store=False)
+        y_ = fp.create_dataset("y", data=y)
+        t_ = fp.create_dataset("t", data=t)
+        yield cls(y_, t_)
+        fp.close()
+
+
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def trace(request, single_beat):
     t, y = single_beat
-    return Trace(y, t)
+    yield from handle_request_param(request, t, y, apf.Trace)
 
 
-@pytest.fixture(scope="session")
-def beat(single_beat):
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def beat(request, single_beat):
     t, y = single_beat
-    return Beat(y, t)
+    yield from handle_request_param(request, t, y, apf.Beat)
 
 
-@pytest.fixture(scope="session")
-def beatseries(multiple_beats):
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def state(request, single_beat, NUM_STATES):
+    t, y = single_beat
+    ys = np.repeat(y, NUM_STATES).reshape(-1, NUM_STATES)
+    yield from handle_request_param(request, t, ys, apf.State)
+
+
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def beatseries(request, multiple_beats):
     t, y = multiple_beats
-    return BeatSeries(y, t)
+    yield from handle_request_param(request, t, y, apf.BeatSeries)
+
+
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def beatcollection(request, single_beat_collection):
+    t, y = single_beat_collection
+    yield from handle_request_param(request, t, y, apf.BeatCollection)
+
+
+@pytest.fixture(scope="session", params=["numpy", "dask", "h5py"])
+def statecollection(request, state_collection_data):
+    t, y = state_collection_data
+    yield from handle_request_param(request, t, y, apf.StateCollection)
 
 
 def test_trace(single_beat, trace):
     t, y = single_beat
-    assert (trace.t == t).all()
-    assert (trace.y == y).all()
-    assert (trace.pacing == 0).all()
+
+    assert (abs(trace.t - t) < 1e-12).all()
+    assert (abs(trace.y - y) < 1e-12).all()
+    assert (abs(trace.pacing - 0) < 1e-12).all()
 
 
 def test_beat(single_beat, beat):
     assert beat.is_valid()
     t, y = single_beat
-    assert (beat.t == t).all()
-    assert (beat.y == y).all()
-    assert (beat.pacing == 0).all()
+    assert (abs(beat.t - t) < 1e-12).all()
+    assert (abs(beat.y - y) < 1e-12).all()
+    assert (abs(beat.pacing - 0) < 1e-12).all()
 
 
 def test_beatseries(beatseries, multiple_beats):
     t, y = multiple_beats
-    assert (beatseries.t == t).all()
-    assert (beatseries.y == y).all()
-    assert (beatseries.pacing == 0).all()
+    assert (abs(beatseries.t - t) < 1e-12).all()
+    assert (abs(beatseries.y - y) < 1e-12).all()
+    assert (abs(beatseries.pacing - 0) < 1e-12).all()
+
+
+def test_beatcollection(beatcollection, single_beat_collection, NUM_TRACES):
+    t, y = single_beat_collection
+    assert (abs(beatcollection.t - t) < 1e-12).all()
+    assert (abs(beatcollection.y - y) < 1e-12).all()
+    assert (abs(beatcollection.pacing - 0) < 1e-12).all()
+    assert beatcollection.num_traces == NUM_TRACES
+
+
+def test_statecollection(
+    statecollection,
+    state_collection_data,
+    NUM_TRACES,
+    NUM_STATES,
+):
+    t, y = state_collection_data
+    assert (abs(statecollection.t - t) < 1e-12).all()
+    assert (abs(statecollection.y - y) < 1e-12).all()
+    assert (abs(statecollection.pacing) - 0 < 1e-12).all()
+    assert statecollection.num_traces == NUM_TRACES
+    assert statecollection.num_states == NUM_STATES
+
+
+def test_state_collection_cost_terms(statecollection, state, NUM_TRACES):
+    c1 = state.cost_terms
+    c2 = statecollection.cost_terms
+    for i in range(NUM_TRACES):
+        assert (abs(c2[i, :] - c1) < 1e-12).all()


### PR DESCRIPTION
Naming is the most difficult problem in programming.
Here I have added a few more classes and my thought are as follows

- A `Trace` is a primitive that does not infer any assumptions
- A `Beat` is a single trace of a single beat, e.g the voltage from one stimulus to another
- A `BeatSeries` is a single trace but can contain multiple beats, e.g several stimulus
- A `BeatCollection` is a collection of multiple traces but only a single beat, e.g a single beat of the voltage computed using different parameter sets
- A `BeatSeriesCollection` is a collection of multiple traces with multiple beats

To make it all a little bit more complicated we would also like to support multiple states, for example both the voltage and calcium. With the above naming convention we can form a similar pattern with instead of Beat we have `State`. 

Feel free to come with different suggestions here. This is difficult.

Also adding a few tests using parameterised fixtures to test that it works using `h5py.Dataset` and `dask.Array` in addition to `numpy.ndarray`.