### PR TITLE
Turn off OpenMP by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,8 +129,8 @@ def get_extension():
 
     extra_compile_args = []
     extra_link_args = []
-    disable_openmp = "DISABLE_OPENMP" in os.environ
-    if not disable_openmp and check_for_openmp():
+    enable_openmp = "ENABLE_OPENMP" in os.environ
+    if enable_openmp and check_for_openmp():
         extra_compile_args = get_openmp_compile_args()
         extra_link_args = get_openmp_link_args()
 


### PR DESCRIPTION
Since most people will use this library for pretty simple things that doesn't require OpenMP I think it is best to turn this off by default and make it possible to enable it by setting the environment variable `ENABLE_OPENMP=1`. That way it is also less likely to fail in the installation due to compiler errors such as `ld: library not found for -lomp`.