### PR TITLE
Fix weired bug in APD when the sign of an array becomes zero

### DIFF
--- a/src/python/ap_features/features.py
+++ b/src/python/ap_features/features.py
@@ -199,6 +199,17 @@ def apd(
         return _numba.apd(V=y, T=x, factor=factor)
 
 
+def sign_change(y: np.ndarray) -> np.ndarray:
+    s = np.sign(y)
+
+    # If we have many zero values just use these instead
+    num_zeros = len(s[s == 0])
+    if num_zeros > 1:
+        return np.where(s == 0)[0]
+
+    return np.where(np.diff(np.sign(y)))[0]
+
+
 def apd_point(
     factor: float,
     V: Array,
@@ -251,10 +262,11 @@ def apd_point(
 
         inds = f.roots()
         if len(inds) == 1:
+
             # Safety guard for strange interpolations
-            inds = t[np.where(np.diff(np.sign(y)))[0]]
+            inds = t[sign_change(y)]
     else:
-        inds = t[np.where(np.diff(np.sign(y)))[0]]
+        inds = t[sign_change(y)]
     if len(inds) == 0:
         logger.warning("Warning: no root was found for APD {}".format(factor))
         x1 = x2 = 0

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2,7 +2,6 @@ import itertools as it
 import os
 
 import ap_features as apf
-import ap_features as cost_terms
 import numpy as np
 import pytest
 
@@ -12,12 +11,13 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.mark.parametrize(
     "factor, backend",
-    it.product(range(10, 95, 5), cost_terms.Backend),
+    it.product(range(10, 95, 5), apf.Backend),
 )
 def test_apds_triangle_signal(factor, backend, triangle_signal):
     x, y = triangle_signal
 
-    apd = cost_terms.apd(V=y, t=x, factor=factor, backend=backend)
+    apd = apf.apd(V=y, t=x, factor=factor, backend=backend)
+
     assert abs(apd - 2 * factor) < 1e-10
 
 
@@ -37,20 +37,20 @@ def test_apdxy_triangle_signal(factor_x, factor_y, backend, triangle_signal):
 
 
 def test_number_of_cost_terms():
-    assert cost_terms.NUM_COST_TERMS == len(cost_terms.list_cost_function_terms())
+    assert apf.NUM_COST_TERMS == len(apf.list_cost_function_terms())
 
 
 def test_number_of_cost_terms_trace():
-    assert cost_terms.NUM_COST_TERMS // 2 == len(
-        cost_terms.list_cost_function_terms_trace(),
+    assert apf.NUM_COST_TERMS // 2 == len(
+        apf.list_cost_function_terms_trace(),
     )
 
 
 def test_compare_python_matlab(synthetic_data):
 
     arr, t, expected_cost = synthetic_data
-    cost = cost_terms.cost_terms(v=arr[0, :], ca=arr[1, :], t_v=t, t_ca=t)
-    lst = cost_terms.list_cost_function_terms()
+    cost = apf.cost_terms(v=arr[0, :], ca=arr[1, :], t_v=t, t_ca=t)
+    lst = apf.list_cost_function_terms()
 
     i = 0
     for ri in expected_cost:


### PR DESCRIPTION
For some cases (APD40 and APD50) the tests for `apd` fails on my Mac M1. I manage to figure out that it came from `numpy.sign(y)` gave a zero value in some cases, while these zeros where never present on my old Mac. According to the [docs](https://numpy.org/doc/stable/reference/generated/numpy.sign.html) `numpy.sign` should return 0 if the value is zero, but perhaps there is something different with the floating point precision on my Mac M1.

Anyway, here is a possible fix. I suspect we will never hit this special case for real data, but it is good to have passing tests on artificial data.