### PR TITLE
Improve averaging by accepting traces with different start point

### DIFF
--- a/src/python/ap_features/__init__.py
+++ b/src/python/ap_features/__init__.py
@@ -21,7 +21,7 @@ from ._numba import transpose_trace_array
 from .beat import Beat, Beats, Trace, BeatCollection, StateCollection, State
 from .features import all_cost_terms, apd, apd_up_xy, cost_terms, cost_terms_trace
 from .utils import Backend, list_cost_function_terms, list_cost_function_terms_trace
-from .average import average_and_interpolate, average_list
+from .average import average_and_interpolate
 from .background import BackgroundCorrection as BC
 
 
@@ -64,7 +64,6 @@ __all__ = [
     "State",
     "average",
     "average_and_interpolate",
-    "average_list",
     "filters",
     "BC",
     "plot",

--- a/src/python/ap_features/beat.py
+++ b/src/python/ap_features/beat.py
@@ -603,15 +603,8 @@ def align_beats(beats: List[Beat], apd_point=50, N=200, parent=None):
     apd_points = [b.apd_point(apd_point)[0] for b in new_beats]
     apd_points = np.subtract(apd_points, min(apd_points))
     xs = [xi - p for (xi, p) in zip(xs, apd_points)]
-    start = max(map(min, xs))  # Should be 0
-    end = min(map(max, xs))
-    X = np.linspace(start, end, N)
-    ys = [
-        average.interpolate(np.linspace(start, end, N), xi, yi)
-        for (xi, yi) in zip(xs, ys)
-    ]
 
-    return [Beat(yi, X, parent=parent) for yi in ys]
+    return [Beat(yi, xi, parent=parent) for (yi, xi) in zip(ys, xs)]
 
 
 def average_beat(
@@ -620,11 +613,13 @@ def average_beat(
     filters: Optional[Sequence[_filters.Filters]] = None,
     x: float = 1.0,
 ) -> Beat:
+
     if len(beats) == 0:
         raise ValueError("Cannot average an empty list")
     if filters is not None:
         beats = filter_beats(beats, filters=filters, x=x)
     beats = align_beats(beats, N=N)
+
     avg = average.average_and_interpolate([b.y for b in beats], [b.t for b in beats], N)
 
     pacing_avg = np.interp(

--- a/src/python/ap_features/beat.py
+++ b/src/python/ap_features/beat.py
@@ -597,12 +597,21 @@ def align_beats(beats: List[Beat], apd_point=50, N=200, parent=None):
 
     if len(beats) == 0:
         return beats
-    xs = [beat.t - beat.t[0] for beat in beats]
-    ys = [beat.y for beat in beats]
-    new_beats = [Beat(yi, xi) for (xi, yi) in zip(xs, ys)]
-    apd_points = [b.apd_point(apd_point)[0] for b in new_beats]
-    apd_points = np.subtract(apd_points, min(apd_points))
-    xs = [xi - p for (xi, p) in zip(xs, apd_points)]
+
+    apd_points = [b.apd_point(apd_point) for b in beats]
+    bad_beats = [np.isclose(*p) for p in apd_points]
+
+    # Make sure all beats start at time zero
+    xs = [
+        beat.t - ap[0]
+        for (beat, ap, bad) in zip(beats, apd_points, bad_beats)
+        if not bad
+    ]
+    ys = [beat.y for (beat, bad) in zip(beats, bad_beats) if not bad]
+
+    # Make them start at zero
+    min_x = np.min([np.min(xi) for xi in xs])
+    xs = [xi - min_x for xi in xs]
 
     return [Beat(yi, xi, parent=parent) for (yi, xi) in zip(ys, xs)]
 
@@ -620,8 +629,16 @@ def average_beat(
         beats = filter_beats(beats, filters=filters, x=x)
     beats = align_beats(beats, N=N)
 
+    # import matplotlib.pyplot as plt
+
+    # for b in beats:
+    #     plt.plot(b.t, b.y)
+
     avg = average.average_and_interpolate([b.y for b in beats], [b.t for b in beats], N)
 
+    # plt.figure()
+    # plt.plot(avg.x, avg.y)
+    # plt.show()
     pacing_avg = np.interp(
         np.linspace(
             np.min(beats[0].t),
@@ -634,6 +651,7 @@ def average_beat(
 
     pacing_avg[pacing_avg <= 2.5] = 0.0
     pacing_avg[pacing_avg > 2.5] = 5.0
+
     return Beat(y=avg.y, t=avg.x, pacing=pacing_avg, parent=beats[0].parent)
 
 

--- a/tests/test_average.py
+++ b/tests/test_average.py
@@ -13,14 +13,71 @@ import pytest
         ([[1, 1, 1], [3, 3], [2, 2, 5, 5]], [2, 2, 3, 5]),
     ],
 )
-def test_average_list(input, expected_output):
-    output = apf.average_list(input)
-    assert np.isclose(output, expected_output).all()
+def test_average_list_without_xs(input, expected_output):
+    output = apf.average_and_interpolate(input, N=len(expected_output))
+    assert np.isclose(output.y, expected_output).all()
+
+
+@pytest.mark.parametrize(
+    "ys, xs, expected_output, N",
+    [
+        (
+            [[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]],
+            [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+            [1, 1, 1, 1, 1],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [1, 1, 1]],
+            [[0, 1, 2, 3, 4], [0, 1, 2]],
+            [1, 1, 1, 1, 1],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [1, 1, 1]],
+            [[0, 1, 2, 3, 4], [2, 3, 4]],
+            [1, 1, 1, 1, 1],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [3, 3, 3, 3, 3]],
+            [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+            [2, 2, 2, 2, 2],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [3, 3, 3]],
+            [[0, 1, 2, 3, 4], [0, 1, 2]],
+            [2, 2, 2, 1, 1],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [3, 3, 3]],
+            [[0, 1, 2, 3, 4], [2, 3, 4]],
+            [1, 1, 2, 2, 2],
+            5,
+        ),
+        (
+            [[1, 1, 1, 1, 1], [3, 3, 3, 3]],
+            [[0, 1, 2, 3, 4], [2, 3, 4, 5]],
+            [1, 1, 2, 2, 2, 3],
+            6,
+        ),
+    ],
+)
+def test_average_list_with_xs(ys, xs, expected_output, N):
+    output = apf.average_and_interpolate(ys=ys, xs=xs, N=N)
+    assert np.isclose(output.y, expected_output).all()
 
 
 def test_empty_average():
-    avg = apf.average_and_interpolate([], [])
-    assert avg == ([], [], [], [])
+    N = 200
+    avg = apf.average_and_interpolate([], [], N=N)
+
+    assert avg.xs == []
+    assert avg.ys == []
+    assert (avg.y == np.zeros(N)).all()
+    assert (avg.x == np.arange(N)).all()
 
 
 @pytest.mark.parametrize(
@@ -33,9 +90,11 @@ def test_average_and_interpolate_same_length(length, num_beats):
     ys = [i * np.ones(length) for i in range(num_beats)]
     avg = apf.average_and_interpolate(ys, xs, N=length)
 
-    x = [] if len(xs) == 0 else xs[0]
+    x = np.arange(length) if len(xs) == 0 else xs[0]
     assert np.isclose(avg.x, x).all()
-    assert np.isclose(avg.y, np.mean(ys, 0)).all()
+
+    y = np.zeros(length) if len(ys) == 0 else np.mean(ys, 0)
+    assert np.isclose(avg.y, y).all()
     assert len(avg.y) == len(avg.x)
 
 
@@ -64,3 +123,12 @@ def test_raises_Error_on_different_number_of_signals():
 def test_raises_Error_on_different_signal_lengths():
     with pytest.raises(apf.average.InvalidSubSignalError):
         apf.average_and_interpolate([[1], [1, 2]], [[1], [2]])
+
+
+@pytest.mark.parametrize("N", (2, 3, 4, 5, 6))
+def test_create_longest_time_array(N):
+    xs = [[0, 1, 2], [1, 2, 3]]
+    x = apf.average.create_longest_time_array(xs, N)
+    assert len(x) == N
+    assert np.isclose(x[0], 0)
+    assert np.isclose(x[-1], 3)


### PR DESCRIPTION
One core functionality of `af_features` is that it can take a trace with multiple beats and compute an average beat.
The way this has been done in the past is as follows (very simplified)
1. Chop the data into beats using the chopping module
2. Align the beats at the first point of APD50 (i.e intersection of the APD50 line with the upstroke), by moving this point to t=0
3. This will make the first timepoint become negative, so the next step to to add the greatest value of the start point of all the beats. This means that typically one beat will be starting at zero and the rest will be slightly negative. However, it might happen that this beat is not representative (e.g it start during the upstroke for example), in which case the average will also inherit this effect.
4. The average is then computed by interpolating the values and starting all at the same point (chopping of the negative values)

In this PR we will instead use the lowest time value among the beats, which mean that all beats will be included in their entirety. The also means that we need to do the interpolation and averaging a bit differently. 