### PR TITLE
Filter signal before performing background correction

### DIFF
--- a/src/python/ap_features/beat.py
+++ b/src/python/ap_features/beat.py
@@ -1082,7 +1082,7 @@ class Beats(Trace):
     def y(self) -> np.ndarray:
         y = self.background_correction.corrected
         if self._zero_index is not None:
-            y = y - y[self._zero_index]
+            y = np.subtract(y, y[self._zero_index])
         return y
 
     @property


### PR DESCRIPTION
In some cases we the background correction is corrupted due to offsets in the signal. One example is when performing background correction of displacement traces coming from motion tracking software (https://github.com/ComputationalPhysiology/mps_motion)

Here is a simple code that shows the background on the raw and filtered trace (data loaded from a local file)

```python
import numpy as np
import json
import ap_features as apf
from pathlib import Path
import scipy
import matplotlib.pyplot as plt

data = json.loads(Path("mps-data-2023128-191035.json").read_text())

u = data[0]["motion_tracking"]["displacement_norm"]["original"]
t = data[0]["motion_tracking"]["time"]

fig, ax = plt.subplots(2, 1)

ax[0].plot(t, u, label="u")

u_filt = scipy.signal.medfilt(u, kernel_size=13)
ax[0].plot(t, u_filt, label="u filt")


U = apf.background.correct_background(x=t, y=u, method="subtract")
U_filt = apf.background.correct_background(x=t, y=u_filt, method="subtract")

ax[0].plot(t, U.background, label="background (u)")
ax[0].plot(t, U_filt.background, label="background (u filt)")

ax[1].plot(t, U.corrected, label="u new")
ax[1].plot(t, U_filt.corrected, label="u filt new")
ax[1].plot(
    t, np.subtract(u, U_filt.background), linestyle="--", label="u with filtered bkg"
)

fig.subplots_adjust(right=0.7)
for axi in ax:
    axi.legend(bbox_to_anchor=(1.0, 0.5), loc="center left")

fig.savefig("background_correction_filtered.png")
```
![background_correction_filtered](https://user-images.githubusercontent.com/2010323/215353572-bd3a0bc0-1fe3-4cbd-afe7-bfa516c128f2.png)

In this PR we make it possible to pass in a kernel size for a median filtered that is applied before performing the background correction.

