### PR TITLE
Add maximum value and new feature - "time above APD p line"

### DIFF
--- a/src/ap_features/beat.py
+++ b/src/ap_features/beat.py
@@ -161,13 +161,14 @@ class Trace:
             backend=self._backend,
         )
 
-    def copy(self):
+    def copy(self, **kwargs):
         """Create a copy of the trace"""
         return self.__class__(
             y=np.copy(self.y),
             t=np.copy(self.t),
             pacing=np.copy(self.pacing),
             backend=self._backend,
+            **kwargs,
         )
 
     def plot(
@@ -507,6 +508,16 @@ class Beat(Trace):
         pacing = self.pacing if use_pacing else None
         return features.time_to_peak(x=self.t, y=self.y, pacing=pacing)
 
+    def time_above_apd_line(self, factor: float) -> float:
+        """Compute the amount of time spent above APD p line"""
+        return features.time_above_apd_line(
+            V=self.y,
+            t=self.t,
+            factor=factor,
+            v_r=self.y_rest,
+            v_max=self.y_max,
+        )
+
     def integrate_apd(
         self,
         factor: float,
@@ -541,6 +552,7 @@ class Beat(Trace):
         )
 
     def peaks(self, prominence_level: float = 0.1) -> List[int]:
+        """Return the list of peak indices given a prominence level"""
         from scipy.signal import find_peaks
 
         peaks, _ = find_peaks(self.y, prominence=prominence_level)

--- a/src/ap_features/beat.py
+++ b/src/ap_features/beat.py
@@ -234,6 +234,7 @@ class Beat(Trace):
         t: Array,
         pacing: Optional[Array] = None,
         y_rest: Optional[float] = None,
+        y_max: Optional[float] = None,
         parent: Optional["Beats"] = None,
         backend: Backend = Backend.numba,
         beat_number: Optional[int] = None,
@@ -245,18 +246,24 @@ class Beat(Trace):
         )
         assert self._t.shape == self._y.shape, msg
         self._y_rest = y_rest
+        self._y_max = y_max
         self._parent = parent
         self._beat_number = beat_number
 
     @property
     def y_normalized(self) -> np.ndarray:
         """Return normalized signal"""
-        return utils.normalize_signal(self.y, self.y_rest)
+        return utils.normalize_signal(self.y, v_r=self.y_rest, v_max=self.y_max)
 
     @property
     def y_rest(self) -> Optional[float]:
         """Return resting value if specified, otherwise None"""
         return self._y_rest
+
+    @property
+    def y_max(self) -> Optional[float]:
+        """Return maximum value if specified, otherwise None"""
+        return self._y_max
 
     def as_beats(self) -> "Beats":
         """Convert trace from Beat to Beats"""
@@ -303,6 +310,32 @@ class Beat(Trace):
             V=self.y,
             t=self.t,
             v_r=self.y_rest,
+            v_max=self.y_max,
+            use_spline=use_spline,
+        )
+
+    def apd_points(self, factor: float, use_spline: bool = True) -> List[float]:
+        """Return all intersections of the APD p line
+
+        Parameters
+        ----------
+        factor : int
+            The APD
+        use_spline : bool, optional
+            Use spline interpolation or not, by default True
+
+        Returns
+        -------
+        List[float]
+            Two points corresponding to the first and second
+            intersection of the APD p line
+        """
+        return features.apd_points(
+            factor=factor,
+            V=self.y,
+            t=self.t,
+            v_r=self.y_rest,
+            v_max=self.y_max,
             use_spline=use_spline,
         )
 
@@ -326,6 +359,7 @@ class Beat(Trace):
             V=self.y,
             t=self.t,
             v_r=self.y_rest,
+            v_max=self.y_max,
             use_spline=use_spline,
         )
 
@@ -362,6 +396,7 @@ class Beat(Trace):
             low=low,
             high=high,
             v_r=self.y_rest,
+            v_max=self.y_max,
             use_spline=use_spline,
         )
 
@@ -504,6 +539,12 @@ class Beat(Trace):
             use_spline=use_spline,
             normalize=normalize,
         )
+
+    def peaks(self, prominence_level: float = 0.1) -> List[int]:
+        from scipy.signal import find_peaks
+
+        peaks, _ = find_peaks(self.y, prominence=prominence_level)
+        return peaks
 
     def upstroke(self, a: float) -> float:
         """Compute the time from (1-a)*100 % signal

--- a/src/ap_features/features.py
+++ b/src/ap_features/features.py
@@ -381,6 +381,46 @@ def apd_coords(
     return APDCoords(x1, x2, y1, y2, yth)
 
 
+def time_above_apd_line(
+    V: Array,
+    t: Array,
+    factor: float,
+    v_r: Optional[float] = None,
+    v_max: Optional[float] = None,
+) -> float:
+    """Compute the amount of time spent above APD p line
+
+    Parameters
+    ----------
+    V : Array
+        Signal
+    t : Array
+        Time stamps
+    factor : float
+        The p in APD line
+    v_r : Optional[float], optional
+        Resting value, by default None
+    v_max : Optional[float], optional
+        Maximum value, by default None
+
+    Returns
+    -------
+    float
+        Total time spent above the APD p line
+    """
+    y = utils.normalize_signal(V, v_r=v_r, v_max=v_max)
+
+    intersections = np.where(np.diff(y > factor))[0]
+    starts = intersections[::2]
+    ends = intersections[1::2]
+
+    total_time = 0.0
+    for start, end in zip(starts, ends):
+        total_time += t[end] - t[start]
+
+    return total_time
+
+
 def tau(
     x: Array,
     y: Array,

--- a/src/ap_features/features.py
+++ b/src/ap_features/features.py
@@ -410,7 +410,7 @@ def time_above_apd_line(
     """
     y = utils.normalize_signal(V, v_r=v_r, v_max=v_max)
 
-    intersections = np.where(np.diff(y > factor))[0]
+    intersections = np.where(np.diff(y >= factor))[0]
     starts = intersections[::2]
     ends = intersections[1::2]
 

--- a/src/ap_features/utils.py
+++ b/src/ap_features/utils.py
@@ -100,8 +100,10 @@ def normalize_signal(V, v_r: Optional[float] = None, v_max: Optional[float] = No
     ---------
     V : array
         The signal
-    v_r : float
-        The resting value
+    v_r : Optional[float], optional
+        The resting value, by default None. If None the minimum value is chosen
+    v_max : Optional[float], optional
+        The maximum value, by default None. If None the maximum value is chosen
 
     """
 

--- a/src/ap_features/utils.py
+++ b/src/ap_features/utils.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 from typing import Dict
 from typing import List
 from typing import Sequence
@@ -89,7 +89,7 @@ def numpyfy(y) -> np.ndarray:
     return y
 
 
-def normalize_signal(V, v_r=None):
+def normalize_signal(V, v_r: Optional[float] = None, v_max: Optional[float] = None):
     """
     Normalize signal to have maximum value 1
     and zero being the value equal to v_r (resting value).
@@ -106,7 +106,8 @@ def normalize_signal(V, v_r=None):
     """
 
     # Maximum value
-    v_max = np.max(V)
+    if v_max is None:
+        v_max = np.max(V)
 
     # Baseline or resting value
     if v_r is None:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -270,7 +270,7 @@ def test_time_above_apd50_line_multiple(multiple_beats):
     x, y = multiple_beats
     total_time = apf.features.time_above_apd_line(V=y, t=x, factor=0.5)
 
-    assert np.isclose(total_time, 583.0)
+    assert np.isclose(total_time, 579, atol=5)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -259,6 +259,20 @@ def test_maximum_upstroke_velocity(calcium_trace):
     assert np.isclose(max_up, 0.03282385532831371)
 
 
+def test_time_above_apd50_line_single(calcium_trace):
+    x, y = calcium_trace
+    total_time = apf.features.time_above_apd_line(V=y, t=x, factor=0.5)
+
+    assert np.isclose(total_time, 181.818)
+
+
+def test_time_above_apd50_line_multiple(multiple_beats):
+    x, y = multiple_beats
+    total_time = apf.features.time_above_apd_line(V=y, t=x, factor=0.5)
+
+    assert np.isclose(total_time, 583.0)
+
+
 @pytest.mark.parametrize(
     "factor",
     range(10, 90, 5),


### PR DESCRIPTION
Make it possible to set a maximum value in a beat, which is similar to the resting value but represents the maximum value and that is used during normalization. That way it is possible to e.g compute the APD using a different peak value. 

Also add a new feature for computing the time spent above an APD line. 