### PR TITLE
Add padding before filtering signal

### DIFF
--- a/src/ap_features/background.py
+++ b/src/ap_features/background.py
@@ -38,7 +38,14 @@ def get_filtered_signal(y: Array, filter_kernel_size: int = 0) -> Array:
     if filter_kernel_size == 0:
         return y
     else:
-        return medfilt(y, kernel_size=13)
+        n = min(filter_kernel_size, len(y))
+        y_start = np.median(y[:n])
+        y_end = np.median(y[-n:])
+        y_filt = medfilt(
+            np.concatenate((np.ones(n) * y_start, y, np.ones(n) * y_end)),
+            kernel_size=filter_kernel_size,
+        )
+        return y_filt[n:-n]
 
 
 def correct_background(


### PR DESCRIPTION
When performing background correction, we first filter the signal using a median filter. However, this breaks down near the ends of the signal. In this PR we add some padding to the ends to circumvent this problem.


![Unknown-423](https://github.com/ComputationalPhysiology/ap_features/assets/2010323/e9263dd8-a61c-4489-a975-57840575179b)
